### PR TITLE
chore(compose): parameterize creds, add mongo volume, split dev/prod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Copy this file to .env and fill in real values before running `docker compose up`.
+# Rotate any test keys in the Clerk dashboard before using these in production.
+
+# MongoDB
+MONGO_USER=root
+MONGO_PASSWORD=change-me
+MONGO_DB_NAME=app
+
+# Backend
+# Comma-separated list of allowed origins. Use exact origins, not "*".
+BACKEND_CORS_ORIGINS=http://localhost:3000
+
+# Clerk (https://dashboard.clerk.com -> API Keys)
+CLERK_SECRET_KEY=sk_test_replace_me
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_replace_me

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,14 @@
+services:
+  backend:
+    volumes:
+      - ./backend:/app
+    command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+
+  frontend:
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+      - /app/.next
+    environment:
+      - NODE_ENV=development
+    command: bun run dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,15 @@
-
-version: '3.8'
 services:
   mongo:
-    image: mongo:latest
+    image: mongo:7
     restart: always
     ports:
       - "27017:27017"
     environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: example
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
+      MONGO_INITDB_DATABASE: ${MONGO_DB_NAME}
+    volumes:
+      - mongo_data:/data/db
 
   backend:
     build:
@@ -16,12 +17,12 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8000:8000"
-    volumes:
-      - ./backend:/app
     environment:
       - PYTHONUNBUFFERED=1
-      - MONGO_URI=mongodb://root:example@mongo:27017/
-    command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+      - MONGO_URI=mongodb://${MONGO_USER}:${MONGO_PASSWORD}@mongo:27017/
+      - MONGO_DB_NAME=${MONGO_DB_NAME}
+      - CLERK_SECRET_KEY=${CLERK_SECRET_KEY}
+      - BACKEND_CORS_ORIGINS=${BACKEND_CORS_ORIGINS}
     depends_on:
       - mongo
 
@@ -31,12 +32,12 @@ services:
       dockerfile: Dockerfile
     ports:
       - "3000:3000"
-    volumes:
-      - ./frontend:/app
-      - /app/node_modules
     environment:
-      - NODE_ENV=development
-    command: bun start
+      - NODE_ENV=production
+      - NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+      - CLERK_SECRET_KEY=${CLERK_SECRET_KEY}
     depends_on:
       - backend
-      - mongo
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
## Summary
- Replace hardcoded `root`/`example` Mongo credentials with `${MONGO_USER}`/`${MONGO_PASSWORD}` from a root `.env` (template added as `.env.example`).
- Add a named `mongo_data` volume so MongoDB data survives `docker compose down`/`up`.
- Move dev-only bind mounts and `--reload` into a new `docker-compose.override.yml`; base file is now closer to a production-shaped run.
- Drop the obsolete top-level `version: '3.8'` key.

## Test plan
- [x] `cp .env.example .env` and fill values
- [x] `docker compose up --build` brings up Mongo, backend, frontend
- [x] `docker compose down && docker compose up` preserves Mongo data
- [x] `docker compose -f docker-compose.yml up` runs without dev override (prod shape)