### PR TITLE
fix(backend): require env vars instead of falling back to unsafe defaults

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -9,34 +9,35 @@ PROJECT_ROOT = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
 
-# Load the .env file from the project root
 load_dotenv(dotenv_path=os.path.join(PROJECT_ROOT, ".env"))
 
 
+def _required(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(
+            f"Required environment variable {name!r} is not set. "
+            f"Copy .env.example to .env and fill in real values."
+        )
+    return value
+
+
 class Settings:
-    """
-    Application settings class. Reads values from environment variables.
+    """Application settings, populated from environment variables."""
 
-    Attributes:
-        SECRET_KEY (str): Secret key for JWT authentication.
-        ALGORITHM (str): Algorithm used for JWT.
-        ACCESS_TOKEN_EXPIRE_MINUTES (int): JWT token expiration in minutes.
-        ADMIN_USERNAME (str): Username for the initial admin user.
-        MONGO_URL (str): MongoDB connection URL.
-        MONGO_DB_NAME (str): MongoDB database name.
-        LOG_FILE_PATH (str): Path to the log file.
-        LOG_FILE_SIZE (int): Maximum log file size in bytes.
-    """
     LOG_FILE_PATH = os.getenv("LOG_FILE_PATH", "logs/src.log")
-    LOG_FILE_SIZE = int(os.getenv("LOG_FILE_SIZE", 10 * 1024 * 1024))  # Default to 10 MB
+    LOG_FILE_SIZE = int(os.getenv("LOG_FILE_SIZE", 10 * 1024 * 1024))
 
-    MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
-    MONGO_DB_NAME = os.getenv("MONGO_DB_NAME", "test")
+    MONGO_URI = _required("MONGO_URI")
+    MONGO_DB_NAME = os.getenv("MONGO_DB_NAME", "app")
 
-    CLERK_SECRET_KEY = os.getenv("CLERK_SECRET_KEY", "your_clerk_secret_key")
+    CLERK_SECRET_KEY = _required("CLERK_SECRET_KEY")
 
-    BACKEND_CORS_ORIGINS = os.getenv("BACKEND_CORS_ORIGINS", "*").split(",")
+    BACKEND_CORS_ORIGINS = [
+        origin.strip()
+        for origin in _required("BACKEND_CORS_ORIGINS").split(",")
+        if origin.strip()
+    ]
 
 
-# Create a single, importable instance of the settings
 settings = Settings()


### PR DESCRIPTION
## Summary
- `CLERK_SECRET_KEY`, `MONGO_URI`, and `BACKEND_CORS_ORIGINS` now raise `RuntimeError` at import if missing — no more silent boot with the literal string `"your_clerk_secret_key"` or a wide-open `"*"` CORS list.
- `BACKEND_CORS_ORIGINS` is split into a trimmed list of explicit origins.
- Stripped the stale docstring that listed attributes (`SECRET_KEY`, `ALGORITHM`, …) the class doesn't have.

## Test plan
- [ ] `unset CLERK_SECRET_KEY && uv run uvicorn app.main:app` → fails with a clear message
- [ ] With required vars set, app starts normally
- [ ] CORS rejects an origin not listed in `BACKEND_CORS_ORIGINS`