### PR TITLE
refactor(backend): share mongo client across requests

### DIFF
--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -1,9 +1,8 @@
-# app/db/database.py
 import logging
 from typing import cast
 
 from beanie import init_beanie
-from motor.motor_asyncio import AsyncIOMotorClient
+from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
 from pymongo.asynchronous.database import AsyncDatabase
 from pymongo.errors import ConnectionFailure
 
@@ -11,30 +10,33 @@ from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
+_client: AsyncIOMotorClient | None = None
+_db: AsyncIOMotorDatabase | None = None
+
 
 async def init_db() -> AsyncIOMotorClient:
-    """
-    Initializes the database connection and Beanie ODM.
-    This function should be called at application startup.
-    """
+    """Initialize the shared Mongo client and Beanie ODM at startup."""
+    global _client, _db
     try:
-        # Initialize the MongoDB client
-        client = AsyncIOMotorClient(settings.MONGO_URI)
-        db = client[settings.MONGO_DB_NAME]
-
-        # Initialize Beanie with the database
-        await init_beanie(database=cast(AsyncDatabase, db), document_models=[])
-
+        _client = AsyncIOMotorClient(settings.MONGO_URI)
+        _db = _client[settings.MONGO_DB_NAME]
+        # TODO: register Beanie document models here as they are added.
+        await init_beanie(database=cast(AsyncDatabase, _db), document_models=[])
         logger.info("Database connection established successfully.")
-
-        return client
+        return _client
     except ConnectionFailure as e:
         logger.critical(f"Failed to connect to MongoDB: {e}")
-        raise e
+        raise
 
 
-async def close_mongo_connection(client: AsyncIOMotorClient):
-    """Closes the MongoDB connection during application shutdown."""
+def get_db() -> AsyncIOMotorDatabase:
+    """FastAPI dependency that returns the shared Mongo database handle."""
+    if _db is None:
+        raise RuntimeError("Database not initialized. init_db() must run at startup.")
+    return _db
+
+
+async def close_mongo_connection(client: AsyncIOMotorClient) -> None:
     if client:
         logger.info("Closing MongoDB connection...")
         client.close()

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,18 +1,17 @@
-from fastapi import APIRouter
-from motor.motor_asyncio import AsyncIOMotorClient
-from app.core.config import settings
-from pymongo.errors import ConnectionFailure
+from fastapi import APIRouter, Depends
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from pymongo.errors import PyMongoError
+
+from app.db.database import get_db
 
 router = APIRouter()
 
+
 @router.get("/health/db", tags=["Health"])
-async def check_db_connection():
-    """Check if the database is connected properly."""
+async def check_db_connection(db: AsyncIOMotorDatabase = Depends(get_db)):
+    """Check the shared MongoDB connection with a cheap ping."""
     try:
-        client = AsyncIOMotorClient(settings.MONGO_URI, serverSelectionTimeoutMS=2000)
-        # The ismaster command is cheap and does not require auth.
-        await client.admin.command('ping')
-        client.close()
+        await db.command("ping")
         return {"status": "ok", "message": "Database connection successful."}
-    except ConnectionFailure as e:
-        return {"status": "error", "message": f"Database connection failed: {str(e)}"}
+    except PyMongoError as e:
+        return {"status": "error", "message": f"Database connection failed: {e}"}


### PR DESCRIPTION
## Summary
- Promote the Mongo client/db handles to module level in `app/db/database.py`.
- Add `get_db()` FastAPI dependency.
- `/health/db` now reuses the shared db and runs a cheap `db.command("ping")` instead of opening a new client per request.
- TODO comment marks where future Beanie `document_models` should be registered.

## Test plan
- [ ] `docker compose up` then `curl localhost:8000/health/db` → `{"status":"ok",...}`
- [ ] Hammering the endpoint shows no new TCP connections per request