### PR TITLE
fix(frontend): add /about and /contact pages

### DIFF
--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,0 +1,15 @@
+export const metadata = {
+  title: "About — FARM Template",
+};
+
+export default function AboutPage() {
+  return (
+    <main className="max-w-3xl mx-auto px-6 pt-28 pb-16">
+      <h1 className="text-3xl font-semibold mb-4">About</h1>
+      <p className="text-gray-600">
+        FARM Template is a starter combining FastAPI, MongoDB (via Beanie),
+        Next.js, Tailwind, and Clerk authentication.
+      </p>
+    </main>
+  );
+}

--- a/frontend/src/app/contact/page.tsx
+++ b/frontend/src/app/contact/page.tsx
@@ -1,0 +1,14 @@
+export const metadata = {
+  title: "Contact — FARM Template",
+};
+
+export default function ContactPage() {
+  return (
+    <main className="max-w-3xl mx-auto px-6 pt-28 pb-16">
+      <h1 className="text-3xl font-semibold mb-4">Contact</h1>
+      <p className="text-gray-600">
+        Replace this with your contact details or a form.
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
The navbar links to `/about` and `/contact`, but neither route existed — fresh clones 404 on click. Add stub pages so the links resolve.

## Test plan
- [ ] `bun run dev` → click About / Contact in the navbar, both render