### PR TITLE
chore(frontend): drop unused react-router-dom

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,8 +12,7 @@
     "@clerk/nextjs": "^6.27.1",
     "next": "15.4.4",
     "react": "19.1.0",
-    "react-dom": "19.1.0",
-    "react-router-dom": "^7.7.1"
+    "react-dom": "19.1.0"
   },
   "devDependencies": {
     "typescript": "^5",


### PR DESCRIPTION
## Summary
`react-router-dom` is declared in `package.json` but never imported. Next.js App Router handles routing, so this is dead weight and noise in dependency audits.

## Test plan
- [ ] `bun install` regenerates lockfile
- [ ] `bun run lint && bun run build` succeed