### PR TITLE
ci: add pytest smoke tests and GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - run: uv sync --all-groups
+      - run: uv run pytest
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run build
+        env:
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_ci_dummy
+          CLERK_SECRET_KEY: sk_test_ci_dummy

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,3 +13,13 @@ dependencies = [
     "ruff>=0.12.5",
     "uvicorn>=0.35.0",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "httpx>=0.27",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,32 @@
+import os
+
+os.environ.setdefault("MONGO_URI", "mongodb://test:test@localhost:27017/")
+os.environ.setdefault("CLERK_SECRET_KEY", "sk_test_dummy")
+os.environ.setdefault("BACKEND_CORS_ORIGINS", "http://localhost:3000")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.db.database import get_db  # noqa: E402
+from app.main import app  # noqa: E402
+
+
+class _FakeDB:
+    async def command(self, _name: str):
+        return {"ok": 1}
+
+
+app.dependency_overrides[get_db] = lambda: _FakeDB()
+
+
+def test_health_db_ok():
+    with TestClient(app) as client:
+        resp = client.get("/health/db")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+def test_root():
+    with TestClient(app) as client:
+        resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.json() == {"message": "Hello World !"}


### PR DESCRIPTION
## Summary
- Add a tiny pytest suite (`backend/tests/test_health.py`) that exercises `GET /` and `/health/db` with `get_db()` overridden by a fake DB — runs without a live Mongo.
- Add a `[dependency-groups].dev` section with pytest/httpx and a `[tool.pytest.ini_options]` block.
- Add `.github/workflows/ci.yml` with two jobs: backend (`uv sync --all-groups` → `pytest`) and frontend (`bun install` → `lint` → `build` with dummy Clerk env vars).

## Notes
- This PR depends on the `refactor/shared-mongo-client` PR (#7) for the `get_db` import. Merge that first or rebase here.

## Test plan
- [ ] CI runs and both jobs pass on this PR
- [ ] `cd backend && uv run pytest` locally