### PR TITLE
security: stop tracking frontend/.env.local; document env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,14 @@
 # Copy this file to .env and fill in real values before running `docker compose up`.
 # Rotate any test keys in the Clerk dashboard before using these in production.
 
-# MongoDB
+# MongoDB credentials used by the docker-compose mongo service
 MONGO_USER=root
-MONGO_PASSWORD=change-me
+MONGO_PASSWORD=change-me  # change in production
 MONGO_DB_NAME=app
 
-# Backend
-# Comma-separated list of allowed origins. Use exact origins, not "*".
+# FastAPI CORS - comma-separated list of allowed origins. Use exact origins, not "*".
 BACKEND_CORS_ORIGINS=http://localhost:3000
 
-# Clerk (https://dashboard.clerk.com -> API Keys)
+# Clerk auth - get these from https://dashboard.clerk.com/apps -> API Keys
 CLERK_SECRET_KEY=sk_test_replace_me
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_replace_me

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+!.env.local.example
 
 # vercel
 .vercel

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_replace_me
+CLERK_SECRET_KEY=sk_test_replace_me


### PR DESCRIPTION
## Summary

- Adds `frontend/.env.local.example` with placeholder Clerk keys so contributors know what to populate locally.
- Annotates the root `.env.example` with inline comments describing each variable and pointing to the Clerk dashboard for key retrieval.
- Updates `.gitignore` to allow `*.example` files through the broad `.env*` rule (otherwise the example files would be ignored).

`frontend/.env.local` is not currently tracked in the working tree (verified via `git ls-files`), and the existing `.env*` gitignore rule already prevents it from being re-added.

## IMPORTANT - Rotate the leaked Clerk test keys

This PR does NOT remove the previously-committed Clerk test keys from git history. They were committed earlier in `frontend/.env.local` and remain accessible to anyone who clones the repo or browses history on GitHub.

**Action required from a maintainer before merging (or immediately after):**

1. Go to https://dashboard.clerk.com -> the affected app -> API Keys.
2. Rotate (regenerate) both the `CLERK_SECRET_KEY` and `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` for any environment whose keys were exposed.
3. Update local `.env.local` files and any deployment secret stores with the new values.

Optionally, follow up with a history-rewrite (e.g. `git filter-repo`) and force-push, plus invalidate any forks/clones - but key rotation is the only reliable mitigation.

## Context

- `docs/docker-review.md` issue 3
- `docs/frontend-review.md` high-priority item 2

## Test plan

- [x] `git ls-files frontend/.env.local` returns empty
- [x] `frontend/.env.local.example` is tracked and contains placeholders
- [ ] Root `.env.example` documents every variable
- [ ] Clerk keys rotated in the dashboard

Generated with [Claude Code](https://claude.com/claude-code)