### PR TITLE
fix: repair docker-compose YAML and load .env from repo root

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,15 +1,14 @@
 import logging
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
 
-PROJECT_ROOT = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-)
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
-load_dotenv(dotenv_path=os.path.join(PROJECT_ROOT, ".env"))
+load_dotenv(dotenv_path=PROJECT_ROOT / ".env")
 
 
 def _required(name: str) -> str:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,13 +19,11 @@ services:
       - "8000:8000"
     environment:
       - PYTHONUNBUFFERED=1
-      - MONGO_URI=mongodb://root:example@mongo:27017/
-      - BACKEND_CORS_ORIGINS=http://localhost:3000,http://frontend:3000
-    command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
       - MONGO_URI=mongodb://${MONGO_USER}:${MONGO_PASSWORD}@mongo:27017/
       - MONGO_DB_NAME=${MONGO_DB_NAME}
       - CLERK_SECRET_KEY=${CLERK_SECRET_KEY}
       - BACKEND_CORS_ORIGINS=${BACKEND_CORS_ORIGINS}
+    command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     depends_on:
       - mongo
 


### PR DESCRIPTION
## Summary

- Repairs the malformed `backend` service block in `docker-compose.yml`. Previously `command:` was nested inside the `environment:` list, leaving four dangling env entries after it; the compose file failed to parse correctly. The block is now valid YAML with `environment:`, `command:`, and `depends_on:` as siblings.
- Replaces the hardcoded credentials in `MONGO_URI` (`mongodb://root:example@mongo:27017/`) with interpolated `${MONGO_USER}` / `${MONGO_PASSWORD}` from `.env`, matching the documented env contract.
- Fixes `backend/app/core/config.py` so `.env` is loaded from the repo root. The previous code did `os.path.dirname` three times on `__file__`, which resolves to `backend/`, not the project root. Switched to `Path(__file__).resolve().parents[3]` for clarity and correctness.

This is one of three critical-path PRs from `docs/docker-review.md` (issues 1 and 2) and `docs/backend-review.md`.

## Verification

YAML parse (docker not available in the dispatched env, so used PyYAML as the fallback specified in the task):

```
$ python -c "import yaml; yaml.safe_load(open('docker-compose.yml')); print('YAML OK')"
YAML OK
```

`.env` loading from repo root (with a temporary repo-root `.env` containing `MONGO_URI=mongodb://x` and `CLERK_SECRET_KEY=sk_test_x`, deleted after the run):

```
$ cd backend && uv run python -c "from app.core.config import settings; print(settings.MONGO_URI)"
mongodb://x
```

## Test plan

- [ ] Reviewer runs `docker compose config` locally with a populated `.env` and confirms `MONGO_URI` interpolates correctly and the backend service block is well-formed.
- [ ] Reviewer runs `cd backend && uv run pytest` to confirm config loads.
- [ ] Reviewer brings up the stack via `docker compose up --build` and verifies the backend connects to mongo using the interpolated credentials.