### PR TITLE
fix(backend): inject get_db into health check so test overrides work

### DIFF
--- a/backend/app/core/deps.py
+++ b/backend/app/core/deps.py
@@ -1,0 +1,10 @@
+from motor.motor_asyncio import AsyncIOMotorDatabase
+
+from app.db import database as _database
+
+
+def get_db() -> AsyncIOMotorDatabase:
+    """FastAPI dependency that returns the shared Mongo database handle."""
+    if _database._db is None:
+        raise RuntimeError("Database not initialized. init_db() must run at startup.")
+    return _database._db

--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -29,13 +29,6 @@ async def init_db() -> AsyncIOMotorClient:
         raise
 
 
-def get_db() -> AsyncIOMotorDatabase:
-    """FastAPI dependency that returns the shared Mongo database handle."""
-    if _db is None:
-        raise RuntimeError("Database not initialized. init_db() must run at startup.")
-    return _db
-
-
 async def close_mongo_connection(client: AsyncIOMotorClient) -> None:
     if client:
         logger.info("Closing MongoDB connection...")

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -1,7 +1,10 @@
 import logging
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends
+from motor.motor_asyncio import AsyncIOMotorDatabase
 from pymongo.errors import ConnectionFailure
+
+from app.core.deps import get_db
 
 logger = logging.getLogger(__name__)
 
@@ -9,11 +12,10 @@ router = APIRouter()
 
 
 @router.get("/health/db", tags=["Health"])
-async def check_db_connection(request: Request):
+async def check_db_connection(db: AsyncIOMotorDatabase = Depends(get_db)):
     """Check if the database is connected properly."""
     try:
-        client = request.app.state.mongo_client
-        await client.admin.command("ping")
+        await db.command("ping")
         return {"status": "ok", "message": "Database connection successful."}
     except ConnectionFailure as e:
         logger.warning(f"Database connection failed: {e}")

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -6,7 +6,7 @@ os.environ.setdefault("BACKEND_CORS_ORIGINS", "http://localhost:3000")
 
 from fastapi.testclient import TestClient  # noqa: E402
 
-from app.db.database import get_db  # noqa: E402
+from app.core.deps import get_db  # noqa: E402
 from app.main import app  # noqa: E402
 
 


### PR DESCRIPTION
## Summary
- Move `get_db()` from `app.db.database` into `app.core.deps` (its conventional home for FastAPI dependencies).
- Update `app/routers/health.py` to use `Depends(get_db)` instead of reading `request.app.state.mongo_client` directly. The endpoint now calls `db.command("ping")` on the Mongo database handle.
- Update `tests/test_health.py` to import `get_db` from `app.core.deps` so `app.dependency_overrides[get_db]` is actually exercised.

## Why
From `docs/backend-review.md` (high-priority items 1 and 2): the previous health route bypassed FastAPI's dependency injection, so test overrides silently did nothing — tests passed only because lifespan creates a real Mongo client. With this change, the override is now the path of execution under test.

## Verification
\`\`\`
cd backend && uv run pytest -v
============================== 2 passed in 0.86s ==============================
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)